### PR TITLE
[DO NOT MERGE] Ralph Wiggum + sparse index (naive)

### DIFF
--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -269,8 +269,11 @@ static int list_paths(struct string_list *list, const char *with_tree,
 		free(max_prefix);
 	}
 
-	/* TODO: audit for interaction with sparse-index. */
-	ensure_full_index(the_repository->index);
+	/*
+	 * Sparse directory entries have the SKIP_WORKTREE bit set, so they
+	 * will be correctly marked in the result list and skipped by
+	 * add_remove_files(). We don't need to expand the index here.
+	 */
 	for (i = 0; i < the_repository->index->cache_nr; i++) {
 		const struct cache_entry *ce = the_repository->index->cache[i];
 		struct string_list_item *item;

--- a/builtin/difftool.c
+++ b/builtin/difftool.c
@@ -606,9 +606,6 @@ static int run_dir_diff(struct repository *repo,
 	strvec_pushl(&cmd.args, ldir.buf, rdir.buf, NULL);
 	ret = run_command(&cmd);
 
-	/* TODO: audit for interaction with sparse-index. */
-	ensure_full_index(&wtindex);
-
 	/*
 	 * If the diff includes working copy files and those
 	 * files were modified during the diff, then the changes

--- a/entry.c
+++ b/entry.c
@@ -451,8 +451,11 @@ static void mark_colliding_entries(const struct checkout *state,
 
 	ce->ce_flags |= CE_MATCHED;
 
-	/* TODO: audit for interaction with sparse-index. */
-	ensure_full_index(state->istate);
+	/*
+	 * Sparse directory entries always have CE_SKIP_WORKTREE set (they
+	 * represent content outside the sparse cone), so they will be skipped
+	 * by the SKIP_WORKTREE check below. No need to expand the sparse-index.
+	 */
 	for (size_t i = 0; i < state->istate->cache_nr; i++) {
 		struct cache_entry *dup = state->istate->cache[i];
 

--- a/read-cache.c
+++ b/read-cache.c
@@ -3811,9 +3811,11 @@ void overlay_tree_on_index(struct index_state *istate,
 	if (!tree)
 		die("bad tree-ish %s", tree_name);
 
-	/* Hoist the unmerged entries up to stage #3 to make room */
-	/* TODO: audit for interaction with sparse-index. */
-	ensure_full_index(istate);
+	/*
+	 * Hoist the unmerged entries up to stage #3 to make room.
+	 * This is safe with sparse-index because sparse directory entries
+	 * are always at stage 0 and will be skipped by this loop.
+	 */
 	for (i = 0; i < istate->cache_nr; i++) {
 		struct cache_entry *ce = istate->cache[i];
 		if (!ce_stage(ce))

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -2567,4 +2567,14 @@ test_expect_success 'cat-file --batch' '
 	ensure_expanded cat-file --batch <in
 '
 
+test_expect_success 'merge-index does not expand sparse index' '
+	init_repos &&
+
+	# With no unmerged entries, merge-index -a should do nothing
+	# and not expand the sparse index. The command sets
+	# command_requires_full_index = 0, so the index stays sparse.
+	run_sparse_index_trace2 merge-index echo -a &&
+	test_region ! index ensure_full_index trace2.txt
+'
+
 test_done

--- a/t/t1092-sparse-checkout-compatibility.sh
+++ b/t/t1092-sparse-checkout-compatibility.sh
@@ -1497,6 +1497,14 @@ test_expect_success 'sparse-index is not expanded' '
 	ensure_not_expanded commit --include a -m a &&
 	echo >>sparse-index/deep/deeper1/a &&
 	ensure_not_expanded commit --include deep/deeper1/a -m deeper &&
+
+	# Partial commits (git commit -- <paths>) should not expand
+	# (list_paths() and overlay_tree_on_index() are now sparse-aware)
+	echo >>sparse-index/a &&
+	ensure_not_expanded commit -m "partial commit root file" -- a &&
+	echo >>sparse-index/deep/deeper1/a &&
+	ensure_not_expanded commit -m "partial commit deep file" -- deep/deeper1/a &&
+
 	ensure_not_expanded checkout rename-out-to-out &&
 	ensure_not_expanded checkout - &&
 	ensure_not_expanded switch rename-out-to-out &&


### PR DESCRIPTION
# DO NOT MERGE

This PR consists of work done by [Claude Code](https://claude.com/product/claude-code) via [Ralph Orchestrator](https://github.com/mikeyobrien/ralph-orchestrator), given the task to investigate sparse index compatibility and remove `ensure_full_index` calls that can be avoided.

The code here _may_ be usable, but it needs vetting, and to be extracted into granular PRs without hallucinated domain names (someone else owns `bostock.ca` 😅).

This aims to solve the same issues as #8, but Ralph was bootstrapped with a much simpler prompt. Instead of back and forth trying to come up with a big set of requirements and priorities to investigate, I just seeded it with the following naive `PROMPT.md`

> Finish teaching all of git to support sparse indexes, as described in @https://git-scm.com/docs/sparse-index, using a TDD approach.